### PR TITLE
refactor: centralize circle sprite creation

### DIFF
--- a/My project/Assets/Scripts/EnemyAI.cs
+++ b/My project/Assets/Scripts/EnemyAI.cs
@@ -15,7 +15,7 @@ public class EnemyAI : MonoBehaviour
         var sr = GetComponent<SpriteRenderer>();
         if (sr == null)
             sr = gameObject.AddComponent<SpriteRenderer>();
-        sr.sprite = CreateCircleSprite();
+        sr.sprite = SpriteFactory.CreateCircleSprite();
         sr.color = Color.red;
         var shader = Shader.Find("Universal Render Pipeline/2D/Sprite-Unlit-Default");
         if (shader != null)
@@ -46,28 +46,6 @@ public class EnemyAI : MonoBehaviour
         {
             health.TakeDamage(contactDamage);
         }
-    }
-
-    Sprite CreateCircleSprite()
-    {
-        const int size = 32;
-        var tex = new Texture2D(size, size);
-        var center = size / 2f;
-        for (int x = 0; x < size; x++)
-        {
-            for (int y = 0; y < size; y++)
-            {
-                float dx = x - center + 0.5f;
-                float dy = y - center + 0.5f;
-                if (dx * dx + dy * dy <= center * center)
-                    tex.SetPixel(x, y, Color.white);
-                else
-                    tex.SetPixel(x, y, Color.clear);
-            }
-        }
-        tex.filterMode = FilterMode.Point;
-        tex.Apply();
-        return Sprite.Create(tex, new Rect(0, 0, size, size), new Vector2(0.5f, 0.5f), size);
     }
 
 }

--- a/My project/Assets/Scripts/PlayerBootstrap.cs
+++ b/My project/Assets/Scripts/PlayerBootstrap.cs
@@ -24,7 +24,7 @@ public static class PlayerBootstrap
         var sr = player.GetComponent<SpriteRenderer>();
         if (sr == null)
             sr = player.AddComponent<SpriteRenderer>();
-        sr.sprite = CreateCircleSprite();
+        sr.sprite = SpriteFactory.CreateCircleSprite();
         sr.color = Color.yellow;
         var shader = Shader.Find("Universal Render Pipeline/2D/Sprite-Unlit-Default");
         if (shader != null)
@@ -34,25 +34,4 @@ public static class PlayerBootstrap
             player.AddComponent<PlayerController2D>();
     }
 
-    static Sprite CreateCircleSprite()
-    {
-        const int size = 32;
-        var tex = new Texture2D(size, size);
-        var center = size / 2f;
-        for (int x = 0; x < size; x++)
-        {
-            for (int y = 0; y < size; y++)
-            {
-                float dx = x - center + 0.5f;
-                float dy = y - center + 0.5f;
-                if (dx * dx + dy * dy <= center * center)
-                    tex.SetPixel(x, y, Color.white);
-                else
-                    tex.SetPixel(x, y, Color.clear);
-            }
-        }
-        tex.filterMode = FilterMode.Point;
-        tex.Apply();
-        return Sprite.Create(tex, new Rect(0, 0, size, size), new Vector2(0.5f, 0.5f), size);
-    }
 }

--- a/My project/Assets/Scripts/SpriteFactory.cs
+++ b/My project/Assets/Scripts/SpriteFactory.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class SpriteFactory
+{
+    private static readonly Dictionary<int, Sprite> circleCache = new Dictionary<int, Sprite>();
+
+    public static Sprite CreateCircleSprite(int size = 32)
+    {
+        if (!circleCache.TryGetValue(size, out var sprite))
+        {
+            var tex = new Texture2D(size, size);
+            var center = size / 2f;
+            for (int x = 0; x < size; x++)
+            {
+                for (int y = 0; y < size; y++)
+                {
+                    float dx = x - center + 0.5f;
+                    float dy = y - center + 0.5f;
+                    if (dx * dx + dy * dy <= center * center)
+                        tex.SetPixel(x, y, Color.white);
+                    else
+                        tex.SetPixel(x, y, Color.clear);
+                }
+            }
+            tex.filterMode = FilterMode.Point;
+            tex.Apply();
+            sprite = Sprite.Create(tex, new Rect(0, 0, size, size), new Vector2(0.5f, 0.5f), size);
+            circleCache[size] = sprite;
+        }
+        return sprite;
+    }
+}

--- a/My project/Assets/Scripts/SpriteFactory.cs.meta
+++ b/My project/Assets/Scripts/SpriteFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9de9d63cab04eb49210181a246d159e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- refactor player and enemy setup to pull circle sprites from a shared SpriteFactory
- cache generated circle sprites to avoid repeated texture work

## Testing
- `mcs 'My project/Assets/Scripts/'*.cs` *(fails: command not found)*
- `csc 'My project/Assets/Scripts/'*.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c004fc8483319e063bd0ee82ac24